### PR TITLE
@react-native-community/art

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
   "homepage": "https://github.com/nihgwu/react-native-pie#readme",
   "peerDependencies": {
     "prop-types": "^15.6.0"
+  },
+  "dependencies": {
+    "@react-native-community/art": "^1.0.1"
   }
 }

--- a/src/Pie.js
+++ b/src/Pie.js
@@ -1,8 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { ART, Platform } from 'react-native'
-
-const { Surface, Shape, Path, Group } = ART
+import { Platform } from 'react-native'
+import { Surface, Shape, Path, Group } from '@react-native-community/art'
 
 function createPath(cx, cy, r, startAngle, arcAngle) {
   const p = new Path()


### PR DESCRIPTION
React Native ART has been extracted from react-native core and will be removed in a future release. It can now be installed and imported from '@react-native-community/art' instead of 'react-native'. See https://github.com/react-native-community/art