### PR TITLE
Adding sections prop, removing series and colors props

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,27 +33,70 @@ export default class PieDemo extends Component {
   render() {
     return (
       <View style={styles.container}>
-        <Pie
-          radius={100}
-          series={[10, 20, 30, 40]}
-          colors={['red', 'lime', 'blue', 'yellow']} />
-        <Pie
-          radius={100}
-          innerRadius={60}
-          series={[10, 20, 30, 40]}
-          colors={['#f00', '#0f0', '#00f', '#ff0']} />
-        <View>
-          <Pie
-            radius={50}
-            innerRadius={45}
-            series={[60]}
-            colors={['#f00']}
-            backgroundColor='#ddd' />
-          <View style={styles.gauge}>
-            <Text style={styles.gaugeText}>60%</Text>
+            <Pie
+              radius={100}
+              pieSections={[
+                {
+                  percentage: 10,
+                  color: 'red',
+                },
+                {
+                  percentage: 20,
+                  color: 'lime',
+                },
+                {
+                  percentage: 30,
+                  color: 'blue',
+                },
+                {
+                  percentage: 40,
+                  color: 'yellow',
+                },
+              ]}
+            />
+            <Pie
+              radius={100}
+              innerRadius={60}
+              series={[10, 20, 30, 40]}
+              colors={['#f00', '#0f0', '#00f', '#ff0']}
+              pieSections={[
+                {
+                  percentage: 10,
+                  color: '#f00',
+                },
+                {
+                  percentage: 20,
+                  color: '#0f0',
+                },
+                {
+                  percentage: 30,
+                  color: '#00f',
+                },
+                {
+                  percentage: 40,
+                  color: '#ff0',
+                },
+              ]}
+            />
+            <View>
+              <Pie
+                radius={50}
+                innerRadius={45}
+                series={[60]}
+                colors={['#f00']}
+                pieSections={[
+                  {
+                    percentage: 60,
+                    color: '#f00',
+                  },
+                ]}
+                backgroundColor="#ddd"
+              />
+              <View style={styles.gauge}>
+                <Text style={styles.gaugeText}>60%</Text>
+              </View>
+            </View>
           </View>
-        </View>
-      </View>
     )
   }
 }
@@ -81,8 +124,7 @@ const styles = StyleSheet.create({
 
 ## Props
 
-* **series** percentage array, required
-* **colors** pie color array, required
+* **pieSections** `{percentage, color}` of each section in the pie - array, required
 * **radius** `radius = size / 2`, required
 * **innerRadius** default to `0`
 * **backgroundColor** default to `#fff`

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ export default class PieDemo extends Component {
       <View style={styles.container}>
             <Pie
               radius={100}
-              pieSections={[
+              sections={[
                 {
                   percentage: 10,
                   color: 'red',
@@ -57,9 +57,7 @@ export default class PieDemo extends Component {
             <Pie
               radius={100}
               innerRadius={60}
-              series={[10, 20, 30, 40]}
-              colors={['#f00', '#0f0', '#00f', '#ff0']}
-              pieSections={[
+              sections={[
                 {
                   percentage: 10,
                   color: '#f00',
@@ -82,9 +80,7 @@ export default class PieDemo extends Component {
               <Pie
                 radius={50}
                 innerRadius={45}
-                series={[60]}
-                colors={['#f00']}
-                pieSections={[
+                sections={[
                   {
                     percentage: 60,
                     color: '#f00',
@@ -124,7 +120,7 @@ const styles = StyleSheet.create({
 
 ## Props
 
-* **pieSections** `{percentage, color}` of each section in the pie - array, required
+* **sections** `{percentage, color}` of each section in the pie - array, required
 * **radius** `radius = size / 2`, required
 * **innerRadius** default to `0`
 * **backgroundColor** default to `#fff`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pie",
-  "version": "0.7.0",
+  "version": "1.0.0",
   "description": "a pie chart for react native",
   "main": "src/Pie.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pie",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "a pie chart for react native",
   "main": "src/Pie.js",
   "scripts": {

--- a/src/Pie.js
+++ b/src/Pie.js
@@ -46,7 +46,7 @@ const RingShape = props =>
         <ArcShape {...props} startAngle={180} arcAngle={180} />
       </Group>
 
-const Pie = ({ series, colors, radius, innerRadius, backgroundColor,strokeCap}) => {
+const Pie = ({ pieSections, radius, innerRadius, backgroundColor,strokeCap}) => {
   const width = radius - innerRadius
   const backgroundPath = createPath(radius, radius, radius - width / 2, 0, 360)
   let startValue = 0
@@ -59,11 +59,13 @@ const Pie = ({ series, colors, radius, innerRadius, backgroundColor,strokeCap}) 
           strokeWidth={width}
         />
         <RingShape radius={radius} width={width} color={backgroundColor} />
-        {series.map((item, idx) => {
+        {pieSections.map((section, idx) => {
+          const { percentage, color } = section;
+
           const startAngle = startValue / 100 * 360
-          const arcAngle = item / 100 * 360
-          startValue += item
-          const color = colors[idx]
+          const arcAngle = percentage / 100 * 360
+          startValue += percentage
+
           return arcAngle >= 360
             ? <RingShape
                 key={idx}
@@ -89,8 +91,12 @@ const Pie = ({ series, colors, radius, innerRadius, backgroundColor,strokeCap}) 
 export default Pie
 
 Pie.propTypes = {
-  series: PropTypes.arrayOf(PropTypes.number).isRequired,
-  colors: PropTypes.arrayOf(PropTypes.string).isRequired,
+  pieSections: PropTypes.arrayOf(
+    PropTypes.exact({
+      percentage: PropTypes.number.isRequired,
+      color: PropTypes.string.isRequired,
+    }),
+  ).isRequired,
   radius: PropTypes.number.isRequired,
   innerRadius: PropTypes.number,
   backgroundColor: PropTypes.string,

--- a/src/Pie.js
+++ b/src/Pie.js
@@ -46,7 +46,7 @@ const RingShape = props =>
         <ArcShape {...props} startAngle={180} arcAngle={180} />
       </Group>
 
-const Pie = ({ pieSections, radius, innerRadius, backgroundColor,strokeCap}) => {
+const Pie = ({ sections, radius, innerRadius, backgroundColor,strokeCap}) => {
   const width = radius - innerRadius
   const backgroundPath = createPath(radius, radius, radius - width / 2, 0, 360)
   let startValue = 0
@@ -59,7 +59,7 @@ const Pie = ({ pieSections, radius, innerRadius, backgroundColor,strokeCap}) => 
           strokeWidth={width}
         />
         <RingShape radius={radius} width={width} color={backgroundColor} />
-        {pieSections.map((section, idx) => {
+        {sections.map((section, idx) => {
           const { percentage, color } = section;
 
           const startAngle = startValue / 100 * 360
@@ -91,7 +91,7 @@ const Pie = ({ pieSections, radius, innerRadius, backgroundColor,strokeCap}) => 
 export default Pie
 
 Pie.propTypes = {
-  pieSections: PropTypes.arrayOf(
+  sections: PropTypes.arrayOf(
     PropTypes.exact({
       percentage: PropTypes.number.isRequired,
       color: PropTypes.string.isRequired,


### PR DESCRIPTION
<!--Add a helpful description of the defect or user story.-->
## Description
It didn't make much sense to have `colors` and `series` in their own separate arrays, when in reality they are tied to the same logical entity (both work together). I have clubbed them together in a single `sections` object. My argument is this makes the Pie more readable and easier to use. 
<!--Explain the implementation or solution.-->
## Other Details
PropTypes were changed to reflect the new structure.
Changed the readme and examples
Bumped package version to a major because this is a breaking change.
