### PR TITLE
Better curves for rounded divider size less than 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pie",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "a pie chart for react native",
   "main": "src/Pie.js",
   "scripts": {

--- a/src/Pie.js
+++ b/src/Pie.js
@@ -5,7 +5,26 @@ import { Surface, Shape, Path, Group } from '@react-native-community/art';
 
 function createPath(cx, cy, r, startAngle, arcAngle, isBezian, innerRadius) {
   const p = new Path();
-  if (Platform.OS === 'web') {
+  //starting point of our chart
+  if(isBezian && Platform.OS !== 'web'){
+    let ROUNDNESSOUSIDE = 1 - ((r - innerRadius)/ innerRadius) - (arcAngle * .5);
+    let ROUNDNESSINSIDE = 1 + ((r - innerRadius)/ innerRadius) + (arcAngle * .5);
+    const PULLBACK = 0.05;
+    const ANCHORFORWARD = .2 ;
+      //This is for the part that is the divider
+    p.moveTo(cx + r * ROUNDNESSOUSIDE * Math.cos(startAngle + PULLBACK), cy + r * ROUNDNESSOUSIDE * Math.sin(startAngle + PULLBACK));
+    p.onBezierCurve(
+      undefined,
+      undefined,
+      cx + r  * ROUNDNESSOUSIDE * Math.cos(startAngle + PULLBACK),
+      cy + r  * ROUNDNESSOUSIDE * Math.sin(startAngle + PULLBACK),
+      cx + r * Math.cos((startAngle + ANCHORFORWARD)),
+      cy + r * Math.sin((startAngle + ANCHORFORWARD)),
+      cx + r * ROUNDNESSINSIDE * Math.cos(startAngle + PULLBACK),
+      cy + r  * ROUNDNESSINSIDE * Math.sin(startAngle + PULLBACK),
+    );
+  }else{
+    //This is for the main arc of the pie chart
     p.moveTo(cx + r * Math.cos(startAngle), cy + r * Math.sin(startAngle));
     p.onArc(
       undefined,
@@ -18,42 +37,7 @@ function createPath(cx, cy, r, startAngle, arcAngle, isBezian, innerRadius) {
       r,
       startAngle,
       startAngle + arcAngle,
-    );
-  } else {
-  //starting point of our chart
-  if(isBezian){
-    let ROUNDNESSOUSIDE = 1 - ((r - innerRadius)/ innerRadius) - (arcAngle * .5);
-    let ROUNDNESSINSIDE = 1 + ((r - innerRadius)/ innerRadius) + (arcAngle * .5);
-    const PULLBACK = 0.05;
-    const ANCHORFORWARD = .2 ;
-      //This is for the part that is the divider
-      p.moveTo(cx + r * ROUNDNESSOUSIDE * Math.cos(startAngle + PULLBACK), cy + r * ROUNDNESSOUSIDE * Math.sin(startAngle + PULLBACK));
-      p.onBezierCurve(
-        undefined,
-        undefined,
-        cx + r  * ROUNDNESSOUSIDE * Math.cos(startAngle + PULLBACK),
-        cy + r  * ROUNDNESSOUSIDE * Math.sin(startAngle + PULLBACK),
-        cx + r * Math.cos((startAngle + ANCHORFORWARD)),
-        cy + r * Math.sin((startAngle + ANCHORFORWARD)),
-        cx + r * ROUNDNESSINSIDE * Math.cos(startAngle + PULLBACK),
-        cy + r  * ROUNDNESSINSIDE * Math.sin(startAngle + PULLBACK),
-      );
-    }else{
-      //This is for the main arc of the pie chart
-      p.moveTo(cx + r * Math.cos(startAngle), cy + r * Math.sin(startAngle));
-      p.onArc(
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        cx,
-        cy,
-        r,
-        r,
-        startAngle,
-        startAngle + arcAngle,
-      )
-    }
+    )
   }
   return p;
 }
@@ -201,7 +185,11 @@ const Pie = ({ sections, radius, innerRadius, backgroundColor, strokeCap, divide
           backgroundColor={backgroundColor}
           visible={shouldShowRoundDividers}
         />
-        <CleanUpCircles dimensions={dimensions} backgroundColor={backgroundColor} visible={shouldShowRoundDividers}/>
+        <CleanUpCircles 
+          dimensions={dimensions} 
+          backgroundColor={backgroundColor} 
+          visible={shouldShowRoundDividers}
+        />
       </Group>
     </Surface>
   );

--- a/src/Pie.js
+++ b/src/Pie.js
@@ -106,17 +106,19 @@ const LargeBands = ({dimensions, paintedSections, sections, shouldShowRoundDivid
 
 // These are the rounded dividers when strokeCap='round'
 const RoundDividers = ({ dimensions, paintedSections, backgroundColor, visible }) => {
-  const {dividerSize, radius, innerRadius, width} = dimensions;
-  let dividerOffSet = (dividerSize * 2) + 3;
+  let {dividerSize, radius, innerRadius, width} = dimensions;
+  let dividerOffSet = (dividerSize * 2) + 6;
   let strokeCap = 'butt';
   let isBezian = true;
   let dividerColorOverlayArray = [];
   let dividerArray = [];
+  
   if(paintedSections.length > 1 && visible){
+    
     paintedSections.forEach((section, index) => {
       const { color, startAngle } = section;
       
-      for(let i = 0; i < dividerSize * 2; i++){
+      for(let i = 0; i < (dividerSize * 2) + 2; i++){
         dividerArray.push(<ArcShape
           key={index}
           dimensions={dimensions}
@@ -148,11 +150,11 @@ const RoundDividers = ({ dimensions, paintedSections, backgroundColor, visible }
 };
 
 // These circles clean up the strokes left over from the bezian curves
-const CleanUpCircles = ({dimensions, backgroundColor}) => {
+const CleanUpCircles = ({dimensions, backgroundColor, visible}) => {
   const { radius, innerRadius, width} = dimensions;
   const innerBackgroundPath = createPath(radius, radius, innerRadius - ((width) / 2), 0, 360);
   const outerBackgroundPath = createPath(radius, radius, radius + ((width)) / 2, 0, 360);
-  if((width) < 100){
+  if((width) < 100 && visible){
     return (<>
       <Shape
           d={innerBackgroundPath}
@@ -170,8 +172,8 @@ const CleanUpCircles = ({dimensions, backgroundColor}) => {
 }
 
 const Pie = ({ sections, radius, innerRadius, backgroundColor, strokeCap, dividerSize }) => {
-  strokeCapForLargeBands = dividerSize <= 2 || strokeCap == 'butt' ? 'butt' : 'round';
-  const shouldShowRoundDividers = !!dividerSize && strokeCap === 'round';
+  strokeCapForLargeBands = dividerSize > 0 || strokeCap == 'butt' ? 'butt' : 'butt';
+  const shouldShowRoundDividers = strokeCap === 'round';
   let paintedSections = [];
   
   // This is the width for the arc
@@ -199,7 +201,7 @@ const Pie = ({ sections, radius, innerRadius, backgroundColor, strokeCap, divide
           backgroundColor={backgroundColor}
           visible={shouldShowRoundDividers}
         />
-        <CleanUpCircles dimensions={dimensions} backgroundColor={backgroundColor} />
+        <CleanUpCircles dimensions={dimensions} backgroundColor={backgroundColor} visible={shouldShowRoundDividers}/>
       </Group>
     </Surface>
   );

--- a/src/Pie.js
+++ b/src/Pie.js
@@ -90,10 +90,10 @@ const Sections = ({dimensions, paintedSections, sections, shouldShowRoundDivider
 
 // These are the rounded dividers when strokeCap='round'
 const RoundDividers = ({ dimensions, paintedSections, backgroundColor, visible }) => {
-  let {dividerSize, radius, innerRadius, width} = dimensions;
-  let dividerOffSet = (dividerSize * 2) + 6;
-  let strokeCap = 'butt';
-  let isBezian = true;
+  const {dividerSize, radius, innerRadius, width} = dimensions;
+  const dividerOffSet = (dividerSize * 2) + 6;
+  const strokeCap = 'butt';
+  const isBezian = true;
   let dividerColorOverlayArray = [];
   let dividerArray = [];
   

--- a/src/Pie.js
+++ b/src/Pie.js
@@ -140,8 +140,7 @@ const shouldShowDivider = (sections, dividerSize) => sections.length > 1 && !Num
 
 const Pie = ({ sections, radius, innerRadius, backgroundColor, strokeCap, dividerSize }) => {
   const width = radius - innerRadius;
-  //given is round and divider size is <= 2 then we want this to be butt
-  
+  strokeCapBig = dividerSize <= 2 || strokeCap == 'butt' ? 'butt' : 'round';
   //These two paths clean up any left over svg which we dont want to see
   const backgroundPath = createPath(radius, radius, innerRadius - ((radius - innerRadius) / 2), 0, 360);
   const backgroundPath2 = createPath(radius, radius, radius + ((radius - innerRadius)) / 2, 0, 360);
@@ -169,7 +168,7 @@ const Pie = ({ sections, radius, innerRadius, backgroundColor, strokeCap, divide
             color={color}
             startAngle={showDividers ? startAngle + dividerSize : startAngle}
             arcAngle={showDividers ? arcAngle - dividerSize : arcAngle}
-            strokeCap={'butt'}
+            strokeCap={strokeCapBig}
           />;
         })}
         {shouldShowRoundDividers &&

--- a/src/Pie.js
+++ b/src/Pie.js
@@ -102,7 +102,7 @@ const RoundDividers = ({ dimensions, paintedSections, backgroundColor, visible }
     paintedSections.forEach((section, index) => {
       const { color, startAngle } = section;
       
-      for(let i = 0; i < (dividerSize * 2) + 2; i++){
+      for(let i = 0; i < dividerSize + 2; i++){
         dividerArray.push(<ArcShape
           key={index}
           dimensions={dimensions}

--- a/src/Pie.js
+++ b/src/Pie.js
@@ -21,9 +21,7 @@ function createPath(cx, cy, r, startAngle, arcAngle, isBezian, innerRadius) {
     );
   } else {
     
-    //starting point of our chart
-  
-  
+  //starting point of our chart
   if(isBezian){
     const ROUNDNESSOUSIDE = 1 - (r - innerRadius)/ innerRadius;
     const ROUNDNESSINSIDE = 1 + (r - innerRadius)/ innerRadius;
@@ -138,12 +136,18 @@ const getArcAngle = (percentage) => percentage / 100 * 360;
 const shouldShowDivider = (sections, dividerSize) => sections.length > 1 && !Number.isNaN(dividerSize);
 
 const Pie = ({ sections, radius, innerRadius, backgroundColor, strokeCap, dividerSize }) => {
+
+  // This is the width for the arc
   const width = radius - innerRadius;
-  strokeCapBig = dividerSize <= 2 || strokeCap == 'butt' ? 'butt' : 'round';
+
+  strokeCapBigForBigArc = dividerSize <= 2 || strokeCap == 'butt' ? 'butt' : 'round';
+
   //These two paths clean up any left over svg which we dont want to see
-  const backgroundPath = createPath(radius, radius, innerRadius - ((radius - innerRadius) / 2), 0, 360);
-  const backgroundPath2 = createPath(radius, radius, radius + ((radius - innerRadius)) / 2, 0, 360);
+  const innerBackgroundPath = createPath(radius, radius, innerRadius - ((radius - innerRadius) / 2), 0, 360);
+  const outerBackgroundPath = createPath(radius, radius, radius + ((radius - innerRadius)) / 2, 0, 360);
+
   const shouldShowRoundDividers = !!dividerSize && strokeCap === 'round';
+
   let startValue = 0;
   let paintedSections = [];
   const showDividers = shouldShowDivider(sections, dividerSize);
@@ -167,7 +171,7 @@ const Pie = ({ sections, radius, innerRadius, backgroundColor, strokeCap, divide
             color={color}
             startAngle={showDividers ? startAngle + dividerSize : startAngle}
             arcAngle={showDividers ? arcAngle - dividerSize : arcAngle}
-            strokeCap={strokeCapBig}
+            strokeCap={strokeCapBigForBigArc}
           />;
         })}
         {shouldShowRoundDividers &&
@@ -179,14 +183,14 @@ const Pie = ({ sections, radius, innerRadius, backgroundColor, strokeCap, divide
             innerRadius={innerRadius}
           />}
         
-      <Shape
-          d={backgroundPath}
-          stroke={backgroundColor}
-          strokeWidth={width}
-        />
+        <Shape
+            d={innerBackgroundPath}
+            stroke={backgroundColor}
+            strokeWidth={width}
+          />
       
         <Shape
-          d={backgroundPath2}
+          d={outerBackgroundPath}
           stroke={backgroundColor}
           strokeWidth={width}
         />

--- a/src/Pie.js
+++ b/src/Pie.js
@@ -24,8 +24,6 @@ function createPath(cx, cy, r, startAngle, arcAngle, isBezian, innerRadius) {
   if(isBezian){
     let ROUNDNESSOUSIDE = 1 - ((r - innerRadius)/ innerRadius) - (arcAngle * .5);
     let ROUNDNESSINSIDE = 1 + ((r - innerRadius)/ innerRadius) + (arcAngle * .5);
-    // ROUNDNESSOUSIDE -= .05;
-    // ROUNDNESSINSIDE += .05;
     const PULLBACK = 0.05;
     const ANCHORFORWARD = .2 ;
       //This is for the part that is the divider
@@ -61,11 +59,7 @@ function createPath(cx, cy, r, startAngle, arcAngle, isBezian, innerRadius) {
 }
 
 const ArcShape = ({dimensions, color, strokeCap, startAngle, arcAngle, isBezian}) => {
-<<<<<<< HEAD
   const {radius, innerRadius, width, dividerSize} = dimensions;
-=======
-  const {radius, innerRadius, width} = dimensions;
->>>>>>> f5ea3e34239b7f7fb9a4a9828776f11eb82c516f
   const path = createPath(
     radius,
     radius,
@@ -87,11 +81,7 @@ const InitialBand = ({dimensions, color}) => {
 const getArcAngle = (percentage) => percentage / 100 * 360;
 const shouldShowDivider = (sections, dividerSize) => sections.length > 1 && !Number.isNaN(dividerSize);
 
-<<<<<<< HEAD
 const LargeBands = ({dimensions, paintedSections, sections, shouldShowRoundDividers, strokeCapForLargeBands}) => {
-=======
-const LargeBands = ({paintedSections, sections, shouldShowRoundDividers, strokeCapForLargeBands, dimensions}) => {
->>>>>>> f5ea3e34239b7f7fb9a4a9828776f11eb82c516f
   let startValue = 0;
   const {radius, width, dividerSize} = dimensions;
   const showDividers = shouldShowDivider(sections, dividerSize);
@@ -115,15 +105,9 @@ const LargeBands = ({paintedSections, sections, shouldShowRoundDividers, strokeC
 
 
 // These are the rounded dividers when strokeCap='round'
-<<<<<<< HEAD
 const RoundDividers = ({ dimensions, paintedSections, backgroundColor, visible }) => {
   const {dividerSize, radius, innerRadius, width} = dimensions;
   let dividerOffSet = (dividerSize * 2) + 3;
-=======
-const RoundDividers = ({ paintedSections, dimensions, backgroundColor, visible }) => {
-  const {dividerSize, radius, innerRadius, width} = dimensions;
-  let dividerOffSet = 3;
->>>>>>> f5ea3e34239b7f7fb9a4a9828776f11eb82c516f
   let strokeCap = 'butt';
   let isBezian = true;
   let dividerColorOverlayArray = [];
@@ -131,7 +115,6 @@ const RoundDividers = ({ paintedSections, dimensions, backgroundColor, visible }
   if(paintedSections.length > 1 && visible){
     paintedSections.forEach((section, index) => {
       const { color, startAngle } = section;
-<<<<<<< HEAD
       
       for(let i = 0; i < dividerSize * 2; i++){
         dividerArray.push(<ArcShape
@@ -154,27 +137,6 @@ const RoundDividers = ({ paintedSections, dimensions, backgroundColor, visible }
         />);
       }
       
-=======
-      dividerArray.push(<ArcShape
-        key={index}
-        dimensions={dimensions}
-        color={backgroundColor}
-        startAngle={startAngle - dividerSize/ 2 - (dividerOffSet)}
-        arcAngle={dividerSize}
-        isBezian={isBezian}
-        strokeCap={strokeCap}
-      />);
-      
-      dividerColorOverlayArray.push(<ArcShape
-        key={index}
-        dimensions={dimensions}
-        color={color}
-        startAngle={startAngle + section.arcAngle - dividerSize / 2 - (dividerOffSet + 1 && dividerOffSet + 2)}
-        arcAngle={1}
-        isBezian={isBezian}
-        strokeCap={strokeCap}
-      />);
->>>>>>> f5ea3e34239b7f7fb9a4a9828776f11eb82c516f
   });
   }
   return ( 
@@ -196,11 +158,7 @@ const CleanUpCircles = ({dimensions, backgroundColor}) => {
           d={innerBackgroundPath}
           stroke={backgroundColor}
           strokeWidth={width}
-<<<<<<< HEAD
       />
-=======
-        />
->>>>>>> f5ea3e34239b7f7fb9a4a9828776f11eb82c516f
       <Shape
         d={outerBackgroundPath}
         stroke={backgroundColor}

--- a/src/Pie.js
+++ b/src/Pie.js
@@ -22,8 +22,10 @@ function createPath(cx, cy, r, startAngle, arcAngle, isBezian, innerRadius) {
   } else {
   //starting point of our chart
   if(isBezian){
-    const ROUNDNESSOUSIDE = 1 - (r - innerRadius)/ innerRadius;
-    const ROUNDNESSINSIDE = 1 + (r - innerRadius)/ innerRadius;
+    let ROUNDNESSOUSIDE = 1 - ((r - innerRadius)/ innerRadius) - (arcAngle * .5);
+    let ROUNDNESSINSIDE = 1 + ((r - innerRadius)/ innerRadius) + (arcAngle * .5);
+    // ROUNDNESSOUSIDE -= .05;
+    // ROUNDNESSINSIDE += .05;
     const PULLBACK = 0.05;
     const ANCHORFORWARD = .2 ;
       //This is for the part that is the divider
@@ -58,7 +60,8 @@ function createPath(cx, cy, r, startAngle, arcAngle, isBezian, innerRadius) {
   return p;
 }
 
-const ArcShape = ({ radius, width, color, strokeCap, startAngle, arcAngle, isBezian, innerRadius }) => {
+const ArcShape = ({dimensions, color, strokeCap, startAngle, arcAngle, isBezian}) => {
+  const {radius, innerRadius, width, dividerSize} = dimensions;
   const path = createPath(
     radius,
     radius,
@@ -66,89 +69,23 @@ const ArcShape = ({ radius, width, color, strokeCap, startAngle, arcAngle, isBez
     startAngle / 180 * Math.PI,
     arcAngle / 180 * Math.PI,
     isBezian,
-    innerRadius
+    innerRadius,
   );
   const strokeWidth = isBezian ? (arcAngle * 5) : width;
   return <Shape d={path} stroke={color} strokeWidth={strokeWidth} strokeCap={strokeCap} />;
 };
 
-// These are the rounded dividers when strokeCap='round'
-const RoundDividers = ({ paintedSections, dividerSize, width, radius, backgroundColor, innerRadius, visible }) => {
-  let dividerOffSet = 3;
-  let strokeCap = 'butt';
-  let isBezian = true;
-  if(dividerSize > 2){
-    dividerOffSet = 0;
-    strokeCap = 'round';
-    isBezian = false;
-  }
-  let dividerColorOverlayArray = [];
-  let dividerArray = [];
-  if(paintedSections.length > 1 && visible){
-    paintedSections.forEach((section, index) => {
-      const { color, startAngle } = section;
-      dividerArray.push(<ArcShape
-        key={index}
-        radius={radius}
-        width={width}
-        color={backgroundColor}
-        startAngle={startAngle - dividerSize/ 2 - (dividerOffSet)}
-        arcAngle={dividerSize}
-        isBezian={isBezian}
-        innerRadius={innerRadius}
-        strokeCap={strokeCap}
-      />);
-      
-      dividerColorOverlayArray.push(<ArcShape
-        key={index}
-        radius={radius}
-        width={width}
-        color={color}
-        startAngle={startAngle + section.arcAngle - dividerSize / 2 - (dividerOffSet + 1 && dividerOffSet + 2)}
-        arcAngle={1}
-        isBezian={isBezian}
-        innerRadius={innerRadius}
-        strokeCap={strokeCap}
-      />);
-  });
-}
-  return ( 
-    <Group>
-      {dividerArray}
-      {dividerColorOverlayArray}
-    </Group>
-  );
-};
-
-// These circles clean up the strokes left over from the bezian curves
-const CleanUpCircles = ({radius, innerRadius, backgroundColor}) => {
-  const innerBackgroundPath = createPath(radius, radius, innerRadius - ((radius - innerRadius) / 2), 0, 360);
-  const outerBackgroundPath = createPath(radius, radius, radius + ((radius - innerRadius)) / 2, 0, 360);
-  if((radius - innerRadius) < 100){
-    return (<>
-      <Shape
-          d={innerBackgroundPath}
-          stroke={backgroundColor}
-          strokeWidth={radius - innerRadius}
-        />
-      <Shape
-        d={outerBackgroundPath}
-        stroke={backgroundColor}
-        strokeWidth={radius - innerRadius}
-      />
-    </>)
-  }
-  return null;
-  
-}
-
 //The initial band to set the backgroundColor behind the pie chart
-const InitialBand = ({radius, width, color}) => {
-  return <ArcShape radius={radius} width={width} color={color} startAngle={0} arcAngle={360} />
+const InitialBand = ({dimensions, color}) => {
+  return <ArcShape dimensions={dimensions} color={color} startAngle={0} arcAngle={360} />
 }
 
-const LargeBands = ({paintedSections, sections, shouldShowRoundDividers, radius, width, dividerSize}) => {
+const getArcAngle = (percentage) => percentage / 100 * 360;
+const shouldShowDivider = (sections, dividerSize) => sections.length > 1 && !Number.isNaN(dividerSize);
+
+const LargeBands = ({dimensions, paintedSections, sections, shouldShowRoundDividers, strokeCapForLargeBands}) => {
   let startValue = 0;
+  const {radius, width, dividerSize} = dimensions;
   const showDividers = shouldShowDivider(sections, dividerSize);
   paintedSections = sections.map((section, idx) => {
     const { percentage, color } = section;
@@ -158,42 +95,113 @@ const LargeBands = ({paintedSections, sections, shouldShowRoundDividers, radius,
     shouldShowRoundDividers && paintedSections.push({ percentage, color, startAngle, arcAngle });
     return <ArcShape
       key={idx}
-      radius={radius}
-      width={width}
+      dimensions={dimensions}
       color={color}
       startAngle={showDividers ? startAngle + dividerSize : startAngle}
       arcAngle={showDividers ? arcAngle - dividerSize : arcAngle}
-      strokeCap={strokeCapBigForBigArc}
+      strokeCap={strokeCapForLargeBands}
     />;
   })
   return paintedSections;
 }
 
-const getArcAngle = (percentage) => percentage / 100 * 360;
-const shouldShowDivider = (sections, dividerSize) => sections.length > 1 && !Number.isNaN(dividerSize);
+
+// These are the rounded dividers when strokeCap='round'
+const RoundDividers = ({ dimensions, paintedSections, backgroundColor, visible }) => {
+  const {dividerSize, radius, innerRadius, width} = dimensions;
+  let dividerOffSet = (dividerSize * 2) + 3;
+  let strokeCap = 'butt';
+  let isBezian = true;
+  let dividerColorOverlayArray = [];
+  let dividerArray = [];
+  if(paintedSections.length > 1 && visible){
+    paintedSections.forEach((section, index) => {
+      const { color, startAngle } = section;
+      
+      for(let i = 0; i < dividerSize * 2; i++){
+        dividerArray.push(<ArcShape
+          key={index}
+          dimensions={dimensions}
+          color={backgroundColor}
+          startAngle={startAngle + section.arcAngle + dividerSize + i - dividerOffSet}
+          arcAngle={1}
+          isBezian={isBezian}
+          strokeCap={strokeCap}
+        />);
+        dividerColorOverlayArray.push(<ArcShape
+          key={index}
+          dimensions={dimensions}
+          color={color}
+          startAngle={startAngle + section.arcAngle - dividerSize + i - dividerOffSet}
+          arcAngle={1}
+          isBezian={isBezian}
+          strokeCap={strokeCap}
+        />);
+      }
+      
+  });
+  }
+  return ( 
+    <Group>
+      {dividerArray}
+      {dividerColorOverlayArray}
+    </Group>
+  );
+};
+
+// These circles clean up the strokes left over from the bezian curves
+const CleanUpCircles = ({dimensions, backgroundColor}) => {
+  const { radius, innerRadius, width} = dimensions;
+  const innerBackgroundPath = createPath(radius, radius, innerRadius - ((width) / 2), 0, 360);
+  const outerBackgroundPath = createPath(radius, radius, radius + ((width)) / 2, 0, 360);
+  if((width) < 100){
+    return (<>
+      <Shape
+          d={innerBackgroundPath}
+          stroke={backgroundColor}
+          strokeWidth={width}
+      />
+      <Shape
+        d={outerBackgroundPath}
+        stroke={backgroundColor}
+        strokeWidth={width}
+      />
+    </>)
+  }
+  return null;
+}
 
 const Pie = ({ sections, radius, innerRadius, backgroundColor, strokeCap, dividerSize }) => {
-
-  // This is the width for the arc
-  const width = radius - innerRadius;
-  strokeCapBigForBigArc = dividerSize <= 2 || strokeCap == 'butt' ? 'butt' : 'round';
+  strokeCapForLargeBands = dividerSize <= 2 || strokeCap == 'butt' ? 'butt' : 'round';
   const shouldShowRoundDividers = !!dividerSize && strokeCap === 'round';
   let paintedSections = [];
   
+  // This is the width for the arc
+  const width = radius - innerRadius;
+  const dimensions = {
+    radius: radius,
+    innerRadius: innerRadius,
+    width: width,
+    dividerSize: dividerSize,
+  }
   return (
     <Surface width={radius * 2} height={radius * 2}>
       <Group rotation={-90} originX={radius} originY={radius}>
-        <InitialBand radius={radius} width={width} color={backgroundColor} />
-        <LargeBands paintedSections={paintedSections} sections={sections} shouldShowRoundDividers={shouldShowRoundDividers} radius={radius} width={width} dividerSize={dividerSize} />
-        <RoundDividers paintedSections={paintedSections}
+        <InitialBand dimensions={dimensions} color={backgroundColor} />
+        <LargeBands 
+          dimensions={dimensions} 
+          paintedSections={paintedSections} 
+          sections={sections} 
+          strokeCapForLargeBands={strokeCapForLargeBands} 
+          shouldShowRoundDividers={shouldShowRoundDividers} 
+        />
+        <RoundDividers 
+          dimensions={dimensions}
+          paintedSections={paintedSections}
           backgroundColor={backgroundColor}
-          dividerSize={dividerSize}
-          width={width}
-          radius={radius}
-          innerRadius={innerRadius}
           visible={shouldShowRoundDividers}
         />
-        <CleanUpCircles radius={radius} innerRadius={innerRadius} backgroundColor={backgroundColor} />
+        <CleanUpCircles dimensions={dimensions} backgroundColor={backgroundColor} />
       </Group>
     </Surface>
   );

--- a/src/Pie.js
+++ b/src/Pie.js
@@ -42,8 +42,8 @@ function createPath(cx, cy, r, startAngle, arcAngle, isBezian, innerRadius) {
   return p;
 }
 
-const ArcShape = ({dim, color, strokeCap, startAngle, arcAngle, isBezian}) => {
-  const {radius, innerRadius, width, dividerSize} = dim;
+const ArcShape = ({dimensions, color, strokeCap, startAngle, arcAngle, isBezian}) => {
+  const {radius, innerRadius, width, dividerSize} = dimensions;
   const path = createPath(
     radius,
     radius,
@@ -58,16 +58,16 @@ const ArcShape = ({dim, color, strokeCap, startAngle, arcAngle, isBezian}) => {
 };
 
 //The initial band to set the backgroundColor behind the pie chart
-const Background = ({dim, color}) => {
-  return <ArcShape dim={dim} color={color} startAngle={0} arcAngle={360} />
+const Background = ({dimensions, color}) => {
+  return <ArcShape dimensions={dimensions} color={color} startAngle={0} arcAngle={360} />
 }
 
 const getArcAngle = (percentage) => percentage / 100 * 360;
 const shouldShowDivider = (sections, dividerSize) => sections.length > 1 && !Number.isNaN(dividerSize);
 
-const Sections = ({dim, paintedSections, sections, shouldShowRoundDividers, strokeCapForLargeBands}) => {
+const Sections = ({dimensions, paintedSections, sections, shouldShowRoundDividers, strokeCapForLargeBands}) => {
   let startValue = 0;
-  const {radius, width, dividerSize} = dim;
+  const {radius, width, dividerSize} = dimensions;
   const showDividers = shouldShowDivider(sections, dividerSize);
   paintedSections = sections.map((section, idx) => {
     const { percentage, color } = section;
@@ -77,7 +77,7 @@ const Sections = ({dim, paintedSections, sections, shouldShowRoundDividers, stro
     shouldShowRoundDividers && paintedSections.push({ percentage, color, startAngle, arcAngle });
     return <ArcShape
       key={idx}
-      dim={dim}
+      dimensions={dimensions}
       color={color}
       startAngle={showDividers ? startAngle + dividerSize : startAngle}
       arcAngle={showDividers ? arcAngle - dividerSize : arcAngle}
@@ -89,8 +89,8 @@ const Sections = ({dim, paintedSections, sections, shouldShowRoundDividers, stro
 
 
 // These are the rounded dividers when strokeCap='round'
-const RoundDividers = ({ dim, paintedSections, backgroundColor, visible }) => {
-  let {dividerSize, radius, innerRadius, width} = dim;
+const RoundDividers = ({ dimensions, paintedSections, backgroundColor, visible }) => {
+  let {dividerSize, radius, innerRadius, width} = dimensions;
   let dividerOffSet = (dividerSize * 2) + 6;
   let strokeCap = 'butt';
   let isBezian = true;
@@ -105,7 +105,7 @@ const RoundDividers = ({ dim, paintedSections, backgroundColor, visible }) => {
       for(let i = 0; i < dividerSize + 2; i++){
         dividerArray.push(<ArcShape
           key={index}
-          dim={dim}
+          dimensions={dimensions}
           color={backgroundColor}
           startAngle={startAngle + section.arcAngle + dividerSize + i - dividerOffSet}
           arcAngle={1}
@@ -114,7 +114,7 @@ const RoundDividers = ({ dim, paintedSections, backgroundColor, visible }) => {
         />);
         dividerColorOverlayArray.push(<ArcShape
           key={index}
-          dim={dim}
+          dimensions={dimensions}
           color={color}
           startAngle={startAngle + section.arcAngle - dividerSize + i - dividerOffSet}
           arcAngle={1}
@@ -134,8 +134,8 @@ const RoundDividers = ({ dim, paintedSections, backgroundColor, visible }) => {
 };
 
 // These circles clean up the strokes left over from the bezian curves
-const CleanUpCircles = ({dim, backgroundColor, visible}) => {
-  const { radius, innerRadius, width} = dim;
+const CleanUpCircles = ({dimensions, backgroundColor, visible}) => {
+  const { radius, innerRadius, width} = dimensions;
   const innerBackgroundPath = createPath(radius, radius, innerRadius - ((width) / 2), 0, 360);
   const outerBackgroundPath = createPath(radius, radius, radius + ((width)) / 2, 0, 360);
   if((width) < 100 && visible){
@@ -162,31 +162,27 @@ const Pie = ({ sections, radius, innerRadius, backgroundColor, strokeCap, divide
   
   // This is the width for the arc
   const width = radius - innerRadius;
-  const dim = {
-    radius: radius,
-    innerRadius: innerRadius,
-    width: width,
-    dividerSize: dividerSize,
-  }
+  const dimensions = { radius, innerRadius, width, dividerSize };
+  
   return (
     <Surface width={radius * 2} height={radius * 2}>
       <Group rotation={-90} originX={radius} originY={radius}>
-        <Background dim={dim} color={backgroundColor} />
+        <Background dimensions={dimensions} color={backgroundColor} />
         <Sections 
-          dim={dim} 
+          dimensions={dimensions} 
           paintedSections={paintedSections} 
           sections={sections} 
           strokeCapForLargeBands={strokeCapForLargeBands} 
           shouldShowRoundDividers={shouldShowRoundDividers} 
         />
         <RoundDividers 
-          dim={dim}
+          dimensions={dimensions}
           paintedSections={paintedSections}
           backgroundColor={backgroundColor}
           visible={shouldShowRoundDividers}
         />
         <CleanUpCircles 
-          dim={dim} 
+          dimensions={dimensions} 
           backgroundColor={backgroundColor} 
           visible={shouldShowRoundDividers}
         />

--- a/src/Pie.js
+++ b/src/Pie.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Platform } from 'react-native';
 import { Surface, Shape, Path, Group } from '@react-native-community/art';
-import { divide } from 'ramda';
 
 function createPath(cx, cy, r, startAngle, arcAngle, isBezian, innerRadius) {
   const p = new Path();


### PR DESCRIPTION
So I changed things to make the curve look slightly better when we have a 
```
strokeCap='round'
dividerSize=2 ( two or less)
radius=145
innerRadius=125
```

its a little messy right now but I am not too sure how to make it much better any help is appreciated 

here's what it looks like with the above settings and the minimum size of the arc's are 3%

<img width="373" alt="Screen Shot 2020-02-10 at 11 34 18 AM" src="https://user-images.githubusercontent.com/46722926/74174355-66b06e80-4bf9-11ea-9872-5263104ea240.png">

